### PR TITLE
Fix podspec to pass validation

### DIFF
--- a/StubKit.podspec
+++ b/StubKit.podspec
@@ -1,11 +1,18 @@
 Pod::Spec.new do |s|
-  s.name         = "StubKit"
-  s.version      = "0.1.2"
-  s.summary      = "A smart stubbing system."
-  s.description  = "StubKit is a smart stubbing system."
-  s.homepage     = "https://github.com/kateinoigakukun/StubKit"
-  s.license      = "MIT"
-  s.author       = { "Yuta Saito" => "kateinoigakukun@gmail.com" }
-  s.source       = { :git => "https://github.com/kateinoigakukun/StubKit", :tag => "#{s.version}" }
-  s.source_files = ["Sources/**/*.swift"]
+  s.name           = "StubKit"
+  s.version        = "0.1.2"
+  s.summary        = "A smart stubbing system."
+  s.description    = "StubKit is a smart stubbing system."
+  s.homepage       = "https://github.com/kateinoigakukun/StubKit"
+  s.license        = "MIT"
+  s.author         = { "Yuta Saito" => "kateinoigakukun@gmail.com" }
+  s.source         = { :git => "https://github.com/kateinoigakukun/StubKit.git", :tag => "#{s.version}" }
+  s.source_files   = ["Sources/**/*.swift"]
+  s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
+
+  s.ios.deployment_target     = '10.0'
+  s.tvos.deployment_target    = '13.3'
+  s.osx.deployment_target     = '10.10'
+  s.watchos.deployment_target = '6.2'
+
 end


### PR DESCRIPTION
## Description

Currently, we can't introduce StubKit via CocoaPods actually due to the validation by CoocaPods.
This PR fixes podspec that mainly adding Swift versions and deployment target OS explicitly to pass validation.
The deployment target versions are followed to the build setting defined in xcproj.
`pod lib lit` is now passed with this PR.

I'm afraid to ask you please release a new version to pods when you have time.
If you can, I want you to push it to CocoaPods. I know the name `StubKit` is already exist, but you can think about push this lib as another name. That's just a pod name, not a module name. GitHub-actions might helps you to push the versions with automation.